### PR TITLE
v0.2.3: prevent words being segmented & other small fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["flit_core >=3.2,<4"]
 
 [project]
 name = "segmentador"
-version = "0.2.2"
+version = "0.2.3"
 description = "Segmentador de textos legislativos da Câmara dos Deputados do Brasil."
 authors = [
     {name="felsiq", email= "felipe.siqueira@usp.br"}
@@ -140,7 +140,7 @@ commands =
 
 [testenv:mypy]
 basepython = python3.9
-deps = mypy
+deps = mypy == 0.991
 commands =
     python -m mypy --install-types --non-interactive src/
     python -m mypy src/
@@ -148,7 +148,7 @@ commands =
 [testenv:pylint]
 basepython = python3.9
 deps =
-    pylint
+    pylint == 2.16.0
     buscador @ git+https://github.com/ulysses-camara/ulysses-fetcher@v0.1.1-beta
     pytest
     datasets

--- a/src/segmentador/__init__.py
+++ b/src/segmentador/__init__.py
@@ -12,4 +12,4 @@ try:
     __version__ = importlib_metadata.version(__name__)
 
 except importlib_metadata.PackageNotFoundError:
-    __version__ = "0.2.2"
+    __version__ = "0.2.3"

--- a/src/segmentador/_base.py
+++ b/src/segmentador/_base.py
@@ -190,6 +190,38 @@ class BaseSegmenter:
 
         return preprocessed_text
 
+    def _set_middle_subword_label_to_noop_(
+        self, input_ids: npt.NDArray[np.int32], logits: npt.NDArray[np.float32], num_tokens: int
+    ) -> npt.NDArray[np.float32]:
+        """Set label to NOOP class for all subwords in the middle of a whole word."""
+        noop_cls_id: int
+
+        try:
+            noop_cls_id = self._model.config.label2id.get("NO_OP", 0)  # type: ignore
+
+        except AttributeError:
+            noop_cls_id = 0
+
+        middle_subword_new_logits = np.zeros(self.NUM_CLASSES, dtype=logits.dtype)
+        middle_subword_new_logits[noop_cls_id] = 1.0
+
+        input_ids = input_ids.ravel()
+
+        logits_shape = logits.shape
+        logits = logits.reshape(-1, self.NUM_CLASSES)
+
+        assert input_ids.size == num_tokens, (input_ids.size, num_tokens)
+        assert logits.shape[0] >= num_tokens, (logits.shape[0], num_tokens)
+
+        subwords = self._tokenizer.convert_ids_to_tokens(input_ids, skip_special_tokens=False)
+        middle_subword_inds = [i for i, sw in enumerate(subwords) if sw.startswith("##")]
+
+        logits[middle_subword_inds, :] = middle_subword_new_logits
+
+        logits = logits.reshape(*logits_shape)
+        assert logits.shape == logits_shape
+        return logits
+
     def _generate_segments_from_labels(
         self,
         tokens: transformers.BatchEncoding,
@@ -418,12 +450,18 @@ class BaseSegmenter:
             window_shift_size=window_shift_size,
         )
 
+        tokens = transformers.BatchEncoding(
+            {key: val.detach().cpu().numpy() for key, val in tokens.items()}
+        )
+
+        logits = self._set_middle_subword_label_to_noop_(
+            input_ids=tokens["input_ids"],
+            logits=logits,
+            num_tokens=num_tokens,
+        )
+
         label_ids = logits.argmax(axis=-1)
         label_ids = label_ids.squeeze()
-
-        tokens = transformers.BatchEncoding(
-            {key: val.cpu().detach().numpy() for key, val in tokens.items()}
-        )
 
         label2id: t.Dict[str, int]
 

--- a/src/segmentador/_base.py
+++ b/src/segmentador/_base.py
@@ -191,8 +191,8 @@ class BaseSegmenter:
         return preprocessed_text
 
     def _set_middle_subword_label_to_noop_(
-        self, input_ids: npt.NDArray[np.int32], logits: npt.NDArray[np.float32], num_tokens: int
-    ) -> npt.NDArray[np.float32]:
+        self, input_ids: npt.NDArray[np.int32], logits: npt.NDArray[np.float64], num_tokens: int
+    ) -> npt.NDArray[np.float64]:
         """Set label to NOOP class for all subwords in the middle of a whole word."""
         noop_cls_id: int
 
@@ -463,18 +463,14 @@ class BaseSegmenter:
         label_ids = logits.argmax(axis=-1)
         label_ids = label_ids.squeeze()
 
-        label2id: t.Dict[str, int]
+        label2id: t.Optional[t.Dict[str, int]]
 
         if remove_noise_subsegments:
             try:
                 label2id = self._model.config.label2id  # type: ignore
 
             except AttributeError:
-                label2id = dict(
-                    seg_cls_id=1,
-                    noise_start_cls_id=2,
-                    noise_end_cls_id=3,
-                )
+                label2id = None
 
             label_ids, (logits, *tokens_vals) = output_handlers.remove_noise_subsegments(
                 label_ids,

--- a/src/segmentador/input_handlers/handlers.py
+++ b/src/segmentador/input_handlers/handlers.py
@@ -221,7 +221,7 @@ class InputHandlerMapping(_BaseInputHandler):
             {key: cls._val_to_tensor(val) for key, val in text.items()}
         )
         justificativa = None
-        num_tokens = len(tokens["input_ids"])
+        num_tokens = int(tokens["input_ids"].numel())
 
         return tokens, justificativa, num_tokens
 

--- a/src/segmentador/optimize/models.py
+++ b/src/segmentador/optimize/models.py
@@ -119,7 +119,7 @@ class ONNXBERTSegmenter(_base.BaseSegmenter):
         if isinstance(minibatch, datasets.Dataset):
             minibatch = minibatch.to_dict()
 
-        model_out = self._model.forward(**minibatch)
+        model_out = self._model.forward(**minibatch)  # type: ignore
         model_out = model_out.logits
 
         logits = np.asfarray(model_out)
@@ -235,7 +235,7 @@ class ONNXLSTMSegmenter(_base.BaseSegmenter):
 
         model_out: t.List[npt.NDArray[np.float64]] = self._model.run(
             output_names=["logits"],
-            input_feed=dict(input_ids=input_ids),
+            input_feed={"input_ids": input_ids},
             run_options=None,
         )
 

--- a/src/segmentador/optimize/quantize.py
+++ b/src/segmentador/optimize/quantize.py
@@ -77,11 +77,11 @@ def _build_onnx_default_uris(
     onnx_base_uri = os.path.join(quantized_model_dirpath, intermediary_onnx_model_name)
     onnx_quantized_uri = os.path.join(quantized_model_dirpath, quantized_model_filename)
 
-    paths_dict: t.Dict[str, str] = dict(
-        onnx_base_uri=onnx_base_uri,
-        onnx_quantized_uri=onnx_quantized_uri,
-        output_uri=onnx_quantized_uri,
-    )
+    paths_dict: t.Dict[str, str] = {
+        "onnx_base_uri": onnx_base_uri,
+        "onnx_quantized_uri": onnx_quantized_uri,
+        "output_uri": onnx_quantized_uri,
+    }
 
     paths = QuantizationOutputONNX(**paths_dict)
 
@@ -423,10 +423,10 @@ def quantize_lstm_model_as_onnx(
             opset_version=onnx_opset_version,
             export_params=True,
             do_constant_folding=True,
-            dynamic_axes=dict(
-                input_ids={0: "batch_axis", 1: "sentence_length"},
-                logits={0: "batch_axis", 1: "sentence_length"},
-            ),
+            dynamic_axes={
+                "input_ids": {0: "batch_axis", 1: "sentence_length"},
+                "logits": {0: "batch_axis", 1: "sentence_length"},
+            },
         )
 
     elif verbose:  # pragma: no cover
@@ -564,7 +564,7 @@ def quantize_bert_model_as_torch(
     torch.jit.save(
         m=jit_traced_model,
         f=paths.output_uri,
-        _extra_files=dict(tokenizer=pickled_tokenizer),
+        _extra_files={"tokenizer": pickled_tokenizer},
     )
 
     if verbose:  # pragma: no cover
@@ -693,7 +693,7 @@ def quantize_lstm_model_as_torch(
     torch.jit.save(
         m=jit_traced_model,
         f=paths.output_uri,
-        _extra_files=dict(tokenizer=pickled_tokenizer),
+        _extra_files={"tokenizer": pickled_tokenizer},
     )
 
     if verbose:  # pragma: no cover
@@ -797,13 +797,13 @@ def quantize_model(
             "Please choose either 'onnx' or 'torch_jit'."
         )
 
-    fn_kwargs: t.Dict[str, t.Any] = dict(
-        model=model,
-        quantized_model_filename=quantized_model_filename,
-        quantized_model_dirpath=quantized_model_dirpath,
-        check_cached=check_cached,
-        verbose=verbose,
-    )
+    fn_kwargs: t.Dict[str, t.Any] = {
+        "model": model,
+        "quantized_model_filename": quantized_model_filename,
+        "quantized_model_dirpath": quantized_model_dirpath,
+        "check_cached": check_cached,
+        "verbose": verbose,
+    }
 
     fn_quantization_factory: t.Dict[
         t.Tuple[t.Type[_base.BaseSegmenter], str], t.Callable[..., QuantizationOutput]

--- a/src/segmentador/output_handlers/noise.py
+++ b/src/segmentador/output_handlers/noise.py
@@ -17,7 +17,7 @@ def remove_noise_subsegments(
 ) -> t.Tuple[npt.NDArray[np.int32], t.Tuple[npt.NDArray[t.Any], ...]]:
     """TODO"""
     label2id = label2id or {}
-    seg_cls_id = label2id.get("NOISE_START", 1)
+    seg_cls_id = label2id.get("SEG_START", 1)
     noise_start_cls_id = label2id.get("NOISE_START", 2)
     noise_end_cls_id = label2id.get("NOISE_END", 3)
 

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -44,15 +44,15 @@ def test_model_lstm_inference_time_standard_vs_quantized_torch(
     fixture_model_lstm_1_layer: segmentador.LSTMSegmenter,
     fixture_legal_text_long: str,
 ):
-    common_kwargs = dict(
-        number=20,
-        repeat=3,
-        globals=dict(
-            fixture_quantized_model_lstm_torch=fixture_quantized_model_lstm_torch,
-            fixture_legal_text_long=fixture_legal_text_long,
-            fixture_model_lstm_1_layer=fixture_model_lstm_1_layer,
-        ),
-    )
+    common_kwargs = {
+        "number": 20,
+        "repeat": 3,
+        "globals": {
+            "fixture_quantized_model_lstm_torch": fixture_quantized_model_lstm_torch,
+            "fixture_legal_text_long": fixture_legal_text_long,
+            "fixture_model_lstm_1_layer": fixture_model_lstm_1_layer,
+        },
+    }
 
     times_quantized = timeit.repeat(
         "fixture_quantized_model_lstm_torch(fixture_legal_text_long, batch_size=4)",
@@ -74,15 +74,15 @@ def test_model_lstm_inference_time_standard_vs_quantized_onnx(
     fixture_model_lstm_1_layer: segmentador.LSTMSegmenter,
     fixture_legal_text_long: str,
 ):
-    common_kwargs = dict(
-        number=20,
-        repeat=3,
-        globals=dict(
-            fixture_quantized_model_lstm_onnx=fixture_quantized_model_lstm_onnx,
-            fixture_legal_text_long=fixture_legal_text_long,
-            fixture_model_lstm_1_layer=fixture_model_lstm_1_layer,
-        ),
-    )
+    common_kwargs = {
+        "number": 20,
+        "repeat": 3,
+        "globals": {
+            "fixture_quantized_model_lstm_onnx": fixture_quantized_model_lstm_onnx,
+            "fixture_legal_text_long": fixture_legal_text_long,
+            "fixture_model_lstm_1_layer": fixture_model_lstm_1_layer,
+        },
+    }
 
     times_quantized = timeit.repeat(
         "fixture_quantized_model_lstm_onnx(fixture_legal_text_long, batch_size=4)",
@@ -104,15 +104,15 @@ def test_model_bert_inference_time_standard_vs_quantized_torch(
     fixture_model_bert_2_layers: segmentador.BERTSegmenter,
     fixture_legal_text_long: str,
 ):
-    common_kwargs = dict(
-        number=10,
-        repeat=3,
-        globals=dict(
-            fixture_quantized_model_bert_torch=fixture_quantized_model_bert_torch,
-            fixture_legal_text_long=fixture_legal_text_long,
-            fixture_model_bert_2_layers=fixture_model_bert_2_layers,
-        ),
-    )
+    common_kwargs = {
+        "number": 10,
+        "repeat": 3,
+        "globals": {
+            "fixture_quantized_model_bert_torch": fixture_quantized_model_bert_torch,
+            "fixture_legal_text_long": fixture_legal_text_long,
+            "fixture_model_bert_2_layers": fixture_model_bert_2_layers,
+        },
+    }
 
     times_quantized = timeit.repeat(
         "fixture_quantized_model_bert_torch(fixture_legal_text_long, batch_size=4)",


### PR DESCRIPTION
- Enforce class no-op for middle word subwords, thus preventing words being segmented;
- Add tests to verify if words have not been segmented;
- Fix `num_tokens` calculation in `input_handlers.handlers.InputHandlerMapping`;
- Fix default segment class name in `remove_noise_subsegments` (from "NOISE_START" to "SEG_START").